### PR TITLE
New routes for home page game retrieval

### DIFF
--- a/server/routes/games.js
+++ b/server/routes/games.js
@@ -18,7 +18,8 @@ router.get('/popular', async (req, res) => {
     try {
         const games = await Game.find({ total_rating_count: { $gt: 100 } })
             .sort({ total_rating: -1 })
-            .limit(25);
+            .limit(25)
+            .select('name cover_url igdb_id');
         res.json(games);
     } catch (error) {
         console.error(error);
@@ -31,7 +32,8 @@ router.get('/genre/:genre', async (req, res) => {
     try {
         const games = await Game.find({ genres: new RegExp(genre, 'i') })
             .sort({ total_rating: -1 })
-            .limit(25);
+            .limit(25)
+            .select('name cover_url igdb_id');
         res.json(games);
     } catch (error) {
         console.error(error);

--- a/server/routes/games.js
+++ b/server/routes/games.js
@@ -14,6 +14,31 @@ router.get('/search', async (req, res) => {
     }
 });
 
+router.get('/popular', async (req, res) => {
+    try {
+        const games = await Game.find({ total_rating_count: { $gt: 100 } })
+            .sort({ total_rating: -1 })
+            .limit(25);
+        res.json(games);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Internal server error.' });
+    }
+});
+
+router.get('/genre/:genre', async (req, res) => {
+    const genre = req.params.genre;
+    try {
+        const games = await Game.find({ genres: new RegExp(genre, 'i') })
+            .sort({ total_rating: -1 })
+            .limit(25);
+        res.json(games);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ error: 'Internal server error.' });
+    }
+});
+
 router.get('/:id', async (req, res) => {
     try {
         const game = await Game.findOne({ igdb_id: req.params.id });
@@ -37,7 +62,5 @@ router.post('/similar', async (req, res) => {
         res.status(500).json({ error: 'Internal server error.' });
     }
 });
-
-
 
 module.exports = router;


### PR DESCRIPTION
# Two new endpoints

### `http://localhost:5000/api/games/popular`
- Returns array of top 25 games (`name`, `igdb_id` (for making it clickable to direct to the games page), and `cover_url`)

### `http://localhost:5000/api/games/genre/<genre>`
- For genres, try `shooter`, `adventure`, `platform` for different categories
- Returns same as `/popular`