### PR TITLE
Added delete list endpoint and fixed private list fetching

### DIFF
--- a/client/src/routes/MyListsPage.jsx
+++ b/client/src/routes/MyListsPage.jsx
@@ -13,7 +13,7 @@ function MyListsPage() {
         const fetchLists = async () => {
             try {
                 const response = await axios.get(`http://localhost:5000/api/lists/user/${user._id}`, {
-                    data: { requestingUserId: user._id }
+                    params: { requestingUserId: user._id }
                 });
                 setLists(response.data);
             } catch (error) {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -559,7 +559,7 @@ body {
 }
 
 .review-textarea {
-    width: 97.5%;
+    width: 90%;
     height: 100px;
     padding: 10px;
     border: 1px solid #ccc;
@@ -642,7 +642,7 @@ body {
 
 .list-item {
     padding: 20px;
-    background-color: #f4f4f4;
+    background-color: rgb(83, 82, 82);
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     display: flex;

--- a/server/routes/lists.js
+++ b/server/routes/lists.js
@@ -31,7 +31,7 @@ router.post('/', async (req, res) => {
 // Get list by User
 router.get('/user/:userId', async (req, res) => {
     const { userId } = req.params;
-    const { requestingUserId } = req.body;
+    const { requestingUserId } = req.query;
 
     try {
         let query = { user: userId };
@@ -50,6 +50,7 @@ router.get('/user/:userId', async (req, res) => {
         return res.status(500).json({ error: 'Internal server error' });
     }
 });
+
 
 // Add a game to a list
 router.post('/:listId/games', async (req, res) => {
@@ -96,6 +97,25 @@ router.delete('/:listId/games/:gameId', async (req, res) => {
         return res.status(500).json({ error: 'Internal server error' });
     }
 })
+
+router.delete('/:listId', async (req, res) => {
+    const { listId } = req.params;
+
+    try {
+        const list = await List.findById(listId);
+        if (!list) {
+            return res.status(404).json({ error: 'List not found' });
+        }
+
+        await List.findByIdAndDelete(listId);
+
+        return res.status(200).json({ message: 'List successfully deleted' });
+    } catch (error) {
+        console.error('Error deleting list:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 
 // Set list as public or private
 router.patch('/:listId', async (req, res) => {


### PR DESCRIPTION
The logic for making sure private lists were only fetched if the requesting user was the user who made the list wasn't working, think it's because bodies don't work well with get endpoints. I stuck the requestingUserId in the req query params instead, plus I added a delete list endpoint.